### PR TITLE
PA-81 220204 PR 요청:psycopg2-binary version 변경

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django==3.2.11
-psycopg2-binary
+psycopg2-binary==2.8.6
 gunicorn


### PR DESCRIPTION
## Pull request 내역

- 본인의 이름을 태그해주세요.
- pull 요청자: @Dongmin-Sim 


## 1. 어떤 이유로 MR를 하셨나요?
### Pull request할 때, commit한 이유를 리스트에서 체크하고 설명해주세요.
| PR 이유 | 해당 사항 체크(✅,❎) |
| ------ | ------ |
| feature 병합 |  |
| 버그 수정 |  ✅ |
| 코드 개선 |  |
| 기존 기능 손상 -> 업데이트 필요 |  |
| 기타 (아래에 자세한 내용을 기입해주세요) |  |
- 자세한 내용 :


## 2. 변경 사항이 무엇인가요?

- libpq version 버전 에러가 발생하여 requirements.txt의 psycopg2-binary version을 2.8.6로 변경
- 현재 postgres version : (PostgreSQL) 14.1 (Debian 14.1-1.pgdg110+1)

## 3. 왜 해당 PR이 필요한지 스크린샷 및 세부내용으로 자세하게 설명해주세요.
![image](https://user-images.githubusercontent.com/74139156/152483733-c48fb0fd-fd29-430f-8b6b-0b0dd7c22c67.png)

- apple m1에서 `docker-compose up`으로 도커 이미지 빌드시에 `django.db.utils.OperationalError: SCRAM authentication requires libpq version 10 or above`에러가 발생되면서 django-server가 다운되는 현상 확인

- libpq는 /usr/local/pgsql/lib에 위치 하며, PostgreSQL의 데이터베이스를 다루는데 사용되는 C 라이브러리
- postgres13부터 기본 암호화 방법이 scram-sha-256 로 변경되면서 libpq와 버전이 안맞아 발생하는 문제 같음 [참고](https://support.kaspersky.com/15658)
- @mbmc7442 동훈님 m1 환경에서도 잘 동작하는 지 확인 필요
